### PR TITLE
Update Lamdera Install Version

### DIFF
--- a/src/lamdera/devcontainer-feature.json
+++ b/src/lamdera/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
     "name": "Lamdera",
     "id": "lamdera",
-    "version": "1.0.1",
+    "version": "1.0.2",
     "documentationURL": "https://github.com/joshuanianji/devcontainer-features/tree/main/src/lamdera",
     "description": "Installs [Lamdera](https://dashboard.lamdera.app/), a type-safe full-stack web-app platform for Elm (v1.1.0 and later).",
     "options": {
@@ -9,6 +9,7 @@
             "type": "string",
             "proposals": [
                 "latest",
+                "1.2.1",
                 "1.1.0"
             ],
             "default": "latest",

--- a/src/lamdera/install.sh
+++ b/src/lamdera/install.sh
@@ -51,7 +51,7 @@ install() {
     # Hardcode the latest version of lamdera!!
     # TODO: fix this later!
     if [[ $VERSION == "latest" ]]; then
-        VERSION="1.1.0"
+        VERSION="1.2.1"
     fi
 
     # Download and install lamdera


### PR DESCRIPTION
Debating whether or not I should deprecate this feature, especially now that lamdera has [an npm package](https://www.npmjs.com/package/lamdera).

Fixes #43 