### PR TITLE
[lamdera] Deprecate

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,6 @@ This repo contains my custom devcontainer features.
 
 ## Deprecated Features
 
-| Feature                  | Description                                                                                                             |
+| Feature                  | Description                                                                                                                                         |
 | ------------------------ |
-| [lamdera](./src/lamdera) | Installs [Lamdera](https://dashboard.lamdera.app/), a type-safe full-stack web-app platform for Elm (v1.1.0 and later). |
+| [lamdera](./src/lamdera) | Installs [Lamdera](https://dashboard.lamdera.app/), a type-safe full-stack web-app platform for Elm. Deprecated in favor of the Lamdera NPM package |

--- a/README.md
+++ b/README.md
@@ -12,6 +12,11 @@ This repo contains my custom devcontainer features.
 | [terraform-cli-persistence](./src/terraform-cli-persistence) | Avoid extra logins from the Terraform CLI by preserving the `~/.terraform.d` folder across container instances.                       |
 | [aws-cli-persistence](./src/aws-cli-persistence)             | Avoid extra logins from the AWS CLI by preserving the `~/.aws` folder across container instances.                                     |
 | [gcloud-cli-persistence](./src/gcloud-cli-persistence)       | Avoid extra logins from the Google Cloud CLI by preserving the `~/.config/gcloud` folder across container instances.                  |
-| [lamdera](./src/lamdera)                                     | Installs [Lamdera](https://dashboard.lamdera.app/), a type-safe full-stack web-app platform for Elm (v1.1.0 and later).               |
 | [mount-pnpm-store](./src/mount-pnpm-store)                   | Mounts the pnpm store to a volume to share between multiple devcontainers.                                                            |
 | [edgedb-cli](./src/edgedb-cli)                               | EdgeDB CLI via the official installation script. Includes the VSCode extension and mounts ~/.local/share/edgedb for data persistence. |
+
+## Deprecated Features
+
+| Feature                  | Description                                                                                                             |
+| ------------------------ |
+| [lamdera](./src/lamdera) | Installs [Lamdera](https://dashboard.lamdera.app/), a type-safe full-stack web-app platform for Elm (v1.1.0 and later). |

--- a/src/lamdera/NOTES.md
+++ b/src/lamdera/NOTES.md
@@ -1,6 +1,6 @@
 ## Deprecation notice
 
-This Feature was deprecated in favor of lamdera's NPM package. Lamdera versioning is much better and it's easier to install and manage.
+This Feature was deprecated in favor of lamdera's NPM package. Using NPM is much easier to control and manage, and it's now the recommended way to install lamdera.
 
 ## Lamdera Versions
 

--- a/src/lamdera/NOTES.md
+++ b/src/lamdera/NOTES.md
@@ -1,3 +1,7 @@
+## Deprecation notice
+
+This Feature was deprecated in favor of lamdera's NPM package. Lamdera versioning is much better and it's easier to install and manage.
+
 ## Lamdera Versions
 
 **Latest tag is hardcoded to v1.1.0!** I'm not sure how to get the latest lamdera version automatically (without web scraping the lamdera site which won't be pretty), so currently this is the solution I have.

--- a/src/lamdera/devcontainer-feature.json
+++ b/src/lamdera/devcontainer-feature.json
@@ -2,6 +2,7 @@
     "name": "Lamdera",
     "id": "lamdera",
     "version": "1.0.2",
+    "deprecated": true,
     "documentationURL": "https://github.com/joshuanianji/devcontainer-features/tree/main/src/lamdera",
     "description": "Installs [Lamdera](https://dashboard.lamdera.app/), a type-safe full-stack web-app platform for Elm (v1.1.0 and later).",
     "options": {


### PR DESCRIPTION
Using the lamdera NPM package is much easier, and most Elm applications using Lamdera use npm anyway (e.g. elm-pages)