### PR TITLE
fix(mount-pnpm-store): provide PNPM_HOME/PATH in oncreate.sh so the pnpm global bin dir check passes (fixes #80)

### DIFF
--- a/src/mount-pnpm-store/NOTES.md
+++ b/src/mount-pnpm-store/NOTES.md
@@ -38,9 +38,10 @@ The volume mount is called `global-devcontainer-pnpm-store`, so ensure that no o
 
 ## Changelog
 
-| Version | Notes                                           |
-| ------- | ----------------------------------------------- |
-| 1.0.2   | Move onCreate lifecycle script to `oncreate.sh` |
+| Version | Notes                                                      |
+| ------- | ---------------------------------------------------------- |
+| 1.0.3   | Fix pnpm global bin dir check in `oncreate.sh` (issue #80) |
+| 1.0.2   | Move onCreate lifecycle script to `oncreate.sh`            |
 | 1.0.1   | Fix Docs                                        |
 | 1.0.0   | Support zsh + refactor                          |
 | 0.1.1   | Fix mount name                                  |

--- a/src/mount-pnpm-store/devcontainer-feature.json
+++ b/src/mount-pnpm-store/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
     "name": "Mount pnpm Store",
     "id": "mount-pnpm-store",
-    "version": "1.0.2",
+    "version": "1.0.3",
     "documentationURL": "https://github.com/joshuanianji/devcontainer-features/tree/main/src/mount-pnpm-store",
     "description": "Sets pnpm store to ~/.pnpm-store and mounts it to a volume to share between multiple devcontainers",
     "options": {},

--- a/src/mount-pnpm-store/oncreate.sh
+++ b/src/mount-pnpm-store/oncreate.sh
@@ -2,9 +2,18 @@
 
 set -e
 
+# pnpm refuses --global commands (exit 1) when its global bin directory is
+# not in PATH. This script runs as onCreateCommand in a non-interactive shell
+# where rc-file exports are never loaded, so provide the environment here.
+# The expected directory differs by pnpm version ($PNPM_HOME for pnpm <= 8,
+# $PNPM_HOME/bin for pnpm >= 9), so put both on PATH; neither needs to exist
+# for the check to pass.
+export PNPM_HOME="${PNPM_HOME:-$HOME/.local/share/pnpm}"
+export PATH="$PNPM_HOME/bin:$PNPM_HOME:$PATH"
+
 # set pnpm config (if it's installed)
 if type pnpm >/dev/null 2>&1; then
-    echo "Setting pnpm store location to $_REMOTE_USER_HOME/.pnpm-store"
+    echo "Setting pnpm store location to $HOME/.pnpm-store"
     pnpm config set store-dir ~/.pnpm-store --global
 else
     echo "WARN: pnpm is not installed! Please ensure pnpm is installed and in your PATH."

--- a/test/mount-pnpm-store/node_v2.sh
+++ b/test/mount-pnpm-store/node_v2.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -e
+
+# Regression test for the pnpm >= 9 global bin dir check (issue #80):
+# node feature v2 installs latest pnpm by default, which made the
+# unpatched oncreate.sh fail the container build with
+# "The configured global bin directory ... is not in PATH".
+# Reaching this script at all proves onCreateCommand survived.
+
+# The test shell is non-interactive too, so it needs the same env
+# the patched oncreate.sh provides for itself.
+export PNPM_HOME="${PNPM_HOME:-$HOME/.local/share/pnpm}"
+export PATH="$PNPM_HOME/bin:$PATH"
+
+./_default.sh

--- a/test/mount-pnpm-store/scenarios.json
+++ b/test/mount-pnpm-store/scenarios.json
@@ -12,6 +12,13 @@
             "mount-pnpm-store": {}
         }
     },
+    "node_v2": {
+        "image": "mcr.microsoft.com/devcontainers/base:debian-12",
+        "features": {
+            "ghcr.io/devcontainers/features/node:2": {},
+            "mount-pnpm-store": {}
+        }
+    },
     "zsh_shell": {
         "image": "mcr.microsoft.com/devcontainers/javascript-node:1-18",
         "features": {


### PR DESCRIPTION
## Problem

Fixes #80.

`oncreate.sh` runs `pnpm config set store-dir ~/.pnpm-store --global` as `onCreateCommand`, i.e. in a non-interactive shell where rc-file exports are never loaded. pnpm exits 1 on any `--global` command when its global bin directory is not in `PATH`, so the whole container build fails:

```
Setting pnpm store location to /.pnpm-store
 ERROR  The configured global bin directory "..." is not in PATH
mount-pnpm-store-setup of onCreateCommand from Feature './mount-pnpm-store' failed with exit code 1.
```

This hits anyone using `ghcr.io/devcontainers/features/node:2`, which installs the latest pnpm by default.

## Fix

Export the environment inside `oncreate.sh` itself, so consumers don't need a `remoteEnv`/`containerEnv` workaround:

```sh
export PNPM_HOME="${PNPM_HOME:-$HOME/.local/share/pnpm}"
export PATH="$PNPM_HOME/bin:$PNPM_HOME:$PATH"
```

Both directories go on `PATH` because the expected location differs by pnpm version (verified empirically): pnpm <= 8 checks `$PNPM_HOME`, pnpm >= 9 checks `$PNPM_HOME/bin`. Neither directory needs to exist for the check to pass.

Also replaces `$_REMOTE_USER_HOME` with `$HOME` in the log line — that variable is only set at feature install time and was empty at onCreate (the log said `Setting pnpm store location to /.pnpm-store`).

## Tests

Adds a `node_v2` regression scenario (`base:debian-12` + `node:2`) whose container build fails without this fix. All scenarios pass locally with the fix except `root_user`, which fails for a pre-existing, unrelated reason: the scenarios share the `global-devcontainer-pnpm-store` volume, so by the time `root_user` runs, an earlier non-root scenario has chowned it to uid 1000, and the `_default.sh` ownership check can't pass for root (currently masked in CI by `continue-on-error`). Happy to address that in a follow-up if you want.

## Note

Since we needed the fix immediately, we're running this exact patch in production via a published copy at `ghcr.io/itplusx/devcontainer-features/mount-pnpm-store` ([source](https://github.com/itplusx/devcontainer-features)) — feel free to use it to verify. If this PR lands, we'll deprecate our copy in favor of upstream.
