### PR TITLE
Drop fish shell from tests

### DIFF
--- a/test/aws-cli-persistence/fish_shell.sh
+++ b/test/aws-cli-persistence/fish_shell.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-set -e
-
-# Run default test script (in same folder)
-# See: https://github.com/devcontainers/features/blob/562305d37b97d47331d96306ffc2a0a3cce55e64/test/azure-cli/install_extensions_bookworm.sh
-./_default.sh

--- a/test/aws-cli-persistence/scenarios.json
+++ b/test/aws-cli-persistence/scenarios.json
@@ -16,14 +16,6 @@
             "aws-cli-persistence": {}
         }
     },
-    "fish_shell": {
-        "image": "mcr.microsoft.com/devcontainers/base:debian",
-        "features": {
-            "ghcr.io/meaningful-ooo/devcontainer-features/fish:1": {},
-            "ghcr.io/devcontainers/features/aws-cli": {},
-            "aws-cli-persistence": {}
-        }
-    },
     "root_user": {
         "image": "mcr.microsoft.com/devcontainers/base:debian",
         "features": {

--- a/test/azure-cli-persistence-forked/fish_shell.sh
+++ b/test/azure-cli-persistence-forked/fish_shell.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-set -e
-
-# Run default test script (in same folder)
-# See: https://github.com/devcontainers/features/blob/562305d37b97d47331d96306ffc2a0a3cce55e64/test/azure-cli/install_extensions_bookworm.sh
-./_default.sh

--- a/test/azure-cli-persistence-forked/scenarios.json
+++ b/test/azure-cli-persistence-forked/scenarios.json
@@ -16,14 +16,6 @@
             "azure-cli-persistence-forked": {}
         }
     },
-    "fish_shell": {
-        "image": "mcr.microsoft.com/devcontainers/base:debian",
-        "features": {
-            "ghcr.io/meaningful-ooo/devcontainer-features/fish:1": {},
-            "ghcr.io/devcontainers/features/azure-cli": {},
-            "azure-cli-persistence-forked": {}
-        }
-    },
     "root_user": {
         "image": "mcr.microsoft.com/devcontainers/base:debian",
         "features": {

--- a/test/gcloud-cli-persistence/fish_shell.sh
+++ b/test/gcloud-cli-persistence/fish_shell.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-set -e
-
-# Run default test script (in same folder)
-# See: https://github.com/devcontainers/features/blob/562305d37b97d47331d96306ffc2a0a3cce55e64/test/azure-cli/install_extensions_bookworm.sh
-./_default.sh

--- a/test/gcloud-cli-persistence/scenarios.json
+++ b/test/gcloud-cli-persistence/scenarios.json
@@ -16,14 +16,6 @@
             "gcloud-cli-persistence": {}
         }
     },
-    "fish_shell": {
-        "image": "mcr.microsoft.com/devcontainers/base:debian",
-        "features": {
-            "ghcr.io/meaningful-ooo/devcontainer-features/fish:1": {},
-            "ghcr.io/dhoeric/features/google-cloud-cli": {},
-            "gcloud-cli-persistence": {}
-        }
-    },
     "root_user": {
         "image": "mcr.microsoft.com/devcontainers/base:debian",
         "features": {

--- a/test/github-cli-persistence/fish_shell.sh
+++ b/test/github-cli-persistence/fish_shell.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-set -e
-
-# Run default test script (in same folder)
-# See: https://github.com/devcontainers/features/blob/562305d37b97d47331d96306ffc2a0a3cce55e64/test/azure-cli/install_extensions_bookworm.sh
-./_default.sh

--- a/test/github-cli-persistence/scenarios.json
+++ b/test/github-cli-persistence/scenarios.json
@@ -16,14 +16,6 @@
             "github-cli-persistence": {}
         }
     },
-    "fish_shell": {
-        "image": "mcr.microsoft.com/devcontainers/base:debian",
-        "features": {
-            "ghcr.io/meaningful-ooo/devcontainer-features/fish:1": {},
-            "ghcr.io/devcontainers/features/github-cli": {},
-            "github-cli-persistence": {}
-        }
-    },
     "root_user": {
         "image": "mcr.microsoft.com/devcontainers/base:debian",
         "features": {

--- a/test/lamdera/fish_shell.sh
+++ b/test/lamdera/fish_shell.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-set -e
-
-# Run default test script (in same folder)
-# See: https://github.com/devcontainers/features/blob/562305d37b97d47331d96306ffc2a0a3cce55e64/test/azure-cli/install_extensions_bookworm.sh
-./_default.sh

--- a/test/lamdera/scenarios.json
+++ b/test/lamdera/scenarios.json
@@ -15,12 +15,5 @@
             },
             "lamdera": {}
         }
-    },
-    "fish_shell": {
-        "image": "mcr.microsoft.com/devcontainers/base:debian",
-        "features": {
-            "ghcr.io/meaningful-ooo/devcontainer-features/fish:1": {},
-            "lamdera": {}
-        }
     }
 }

--- a/test/mount-pnpm-store/fish_shell.sh
+++ b/test/mount-pnpm-store/fish_shell.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-set -e
-
-# tests installing pnpm after zsh shell
-
-./_default.sh

--- a/test/mount-pnpm-store/scenarios.json
+++ b/test/mount-pnpm-store/scenarios.json
@@ -28,13 +28,6 @@
             "mount-pnpm-store": {}
         }
     },
-    "fish_shell": {
-        "image": "mcr.microsoft.com/devcontainers/javascript-node:1-18",
-        "features": {
-            "ghcr.io/meaningful-ooo/devcontainer-features/fish:1": {},
-            "mount-pnpm-store": {}
-        }
-    },
     "root_user": {
         "image": "mcr.microsoft.com/devcontainers/javascript-node:1-18",
         "features": {

--- a/test/terraform-cli-persistence/fish_shell.sh
+++ b/test/terraform-cli-persistence/fish_shell.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-set -e
-
-# tests installing pnpm after zsh shell
-
-./_default.sh

--- a/test/terraform-cli-persistence/scenarios.json
+++ b/test/terraform-cli-persistence/scenarios.json
@@ -16,14 +16,6 @@
             "terraform-cli-persistence": {}
         }
     },
-    "fish_shell": {
-        "image": "mcr.microsoft.com/devcontainers/base:debian",
-        "features": {
-            "ghcr.io/meaningful-ooo/devcontainer-features/fish:1": {},
-            "ghcr.io/devcontainers/features/terraform:1": {},
-            "terraform-cli-persistence": {}
-        }
-    },
     "root_user": {
         "image": "mcr.microsoft.com/devcontainers/base:debian",
         "features": {


### PR DESCRIPTION
Fish shell was just causing errors with Debian 13, not worth it to keep around. Fixes *most* tests