### PR TITLE
Pin gcloud scenarios to Debian 12 (bookworm)

### DIFF
--- a/test/gcloud-cli-persistence/scenarios.json
+++ b/test/gcloud-cli-persistence/scenarios.json
@@ -7,7 +7,7 @@
         }
     },
     "zsh_shell": {
-        "image": "mcr.microsoft.com/devcontainers/base:debian",
+        "image": "mcr.microsoft.com/devcontainers/base:debian-12",
         "features": {
             "ghcr.io/devcontainers/features/common-utils:2": {
                 "configureZshAsDefaultShell": true
@@ -25,7 +25,7 @@
         }
     },
     "root_user": {
-        "image": "mcr.microsoft.com/devcontainers/base:debian",
+        "image": "mcr.microsoft.com/devcontainers/base:debian-12",
         "features": {
             "ghcr.io/dhoeric/features/google-cloud-cli": {},
             "gcloud-cli-persistence": {}


### PR DESCRIPTION
Should fix remaining tests (apt-get not available in debian trixie). 

This is a tmp solution. Long term would be for https://github.com/dhoeric/features/pull/36 to be merged, but I might just make my own version of that feature in the meantime. 

---

additional context:

## Why

The `zsh_shell` and `root_user` scenarios for `gcloud-cli-persistence` use the floating base tag `mcr.microsoft.com/devcontainers/base:debian`, which has rolled to **Debian 13 (trixie)**. The third-party `ghcr.io/dhoeric/features/google-cloud-cli` feature imports Google's apt key with `apt-key`:

```sh
curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key --keyring /usr/share/keyrings/cloud.google.gpg add -
```

`apt-key` was **removed in trixie**, so this fails with `apt-key: command not found` (exit 127) and the feature install dies — which is why these scenarios have been red.

## Change

Pin `zsh_shell` and `root_user` to `base:debian-12` (bookworm), where `apt-key` still exists. The `with_node` scenario already runs on a bookworm-based image and passes.

This is a **temporary workaround**. The real fix is upstream switching from `apt-key` to `gpg --dearmor` — see dhoeric/features#36 (open, unmerged). Once that lands and is published, revert this to `base:debian` to restore trixie coverage.

`fish_shell` is intentionally left untouched here — it's removed separately in the fish-scenarios PR.