### PR TITLE
Add google-cloud-cli feature (fixes #90)

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ This repo contains my custom devcontainer features.
 | [github-cli-persistence](./src/github-cli-persistence)       | Avoid extra logins from the Github CLI by preserving the `~/.config/gh` folder across container instances.                                       |
 | [terraform-cli-persistence](./src/terraform-cli-persistence) | Avoid extra logins from the Terraform CLI by preserving the `~/.terraform.d` folder across container instances.                                  |
 | [aws-cli-persistence](./src/aws-cli-persistence)             | Avoid extra logins from the AWS CLI by preserving the `~/.aws` folder across container instances.                                                |
+| [google-cloud-cli](./src/google-cloud-cli)                   | Installs the Google Cloud CLI. Fork of `ghcr.io/dhoeric/features/google-cloud-cli` with a Debian 13 (trixie)-compatible `gpg --dearmor` key import. |
 | [gcloud-cli-persistence](./src/gcloud-cli-persistence)       | Avoid extra logins from the Google Cloud CLI by preserving the `~/.config/gcloud` folder across container instances.                             |
 | [lamdera](./src/lamdera)                                     | Installs [Lamdera](https://dashboard.lamdera.app/), a type-safe full-stack web-app platform for Elm (v1.1.0 and later).                          |
 | [mount-pnpm-store](./src/mount-pnpm-store)                   | Mounts the pnpm store to a volume to share between multiple devcontainers.                                                                       |

--- a/src/google-cloud-cli/NOTES.md
+++ b/src/google-cloud-cli/NOTES.md
@@ -1,0 +1,36 @@
+## Why this fork?
+
+This is a fork of [`ghcr.io/dhoeric/features/google-cloud-cli`](https://github.com/dhoeric/features/tree/main/src/google-cloud-cli). It ships two fixes that have been pending upstream for over half a year:
+
+1. **Trixie-compatible key import.** The upstream feature imports Google's apt key with `apt-key`, which was [removed in Debian 13 (trixie)](https://wiki.debian.org/NewInTrixie) and Ubuntu 24.04, so it fails with `apt-key: command not found` (exit 127) on those distributions. We use `gpg --dearmor` instead (the fix from [dhoeric/features#36](https://github.com/dhoeric/features/pull/36)).
+2. **Working `installGkeGcloudAuthPlugin` option.** The devcontainer feature runtime exposes options as environment variables by uppercasing the option name (`installGkeGcloudAuthPlugin` -> `INSTALLGKEGCLOUDAUTHPLUGIN`, no underscores). The upstream feature reads `INSTALL_GKEGCLOUDAUTH_PLUGIN` (with an underscore), which is never set, so the option silently does nothing. We read the correctly-named variable.
+
+Otherwise the feature is identical to the upstream one (same options, same apt source).
+
+See [joshuanianji/devcontainer-features#90](https://github.com/joshuanianji/devcontainer-features/issues/90).
+
+## Options
+
+| Option | Description | Default |
+| --- | --- | --- |
+| `version` | gcloud CLI version to install (or `latest`) | `latest` |
+| `installGkeGcloudAuthPlugin` | Also install the `gke-gcloud-auth-plugin` package | `false` |
+
+## OS and Architecture Support
+
+Architectures: `amd` and `arm`
+
+OS: `ubuntu`, `debian` (including Debian 13/trixie and Ubuntu 24.04+)
+
+Shells: `bash`, `zsh`, `fish`
+
+## Changelog
+
+| Version | Notes |
+| ------- | ----- |
+| 1.0.0   | Initial fork of `ghcr.io/dhoeric/features/google-cloud-cli@1.0.1` with `gpg --dearmor` key import (fixes [dhoeric/features#36](https://github.com/dhoeric/features/pull/36), [joshuanianji/devcontainer-features#90](https://github.com/joshuanianji/devcontainer-features/issues/90)). |
+
+## References
+
+- Upstream: [dhoeric/features/src/google-cloud-cli](https://github.com/dhoeric/features/tree/main/src/google-cloud-cli)
+- Pending upstream fix: [dhoeric/features#36](https://github.com/dhoeric/features/pull/36)

--- a/src/google-cloud-cli/README.md
+++ b/src/google-cloud-cli/README.md
@@ -1,3 +1,23 @@
+
+# Google Cloud CLI (google-cloud-cli)
+
+Installs the Google Cloud CLI (gcloud) via Google's apt repository. Forked from ghcr.io/dhoeric/features/google-cloud-cli with a trixie-compatible key import (`gpg --dearmor` instead of the removed `apt-key`).
+
+## Example Usage
+
+```json
+"features": {
+    "ghcr.io/joshuanianji/devcontainer-features/google-cloud-cli:1": {}
+}
+```
+
+## Options
+
+| Options Id | Description | Type | Default Value |
+|-----|-----|-----|-----|
+| version | Select or enter a gcloud CLI version | string | latest |
+| installGkeGcloudAuthPlugin | Install 'gke-gcloud-auth-plugin' plugin? | boolean | false |
+
 ## Why this fork?
 
 This is a fork of [`ghcr.io/dhoeric/features/google-cloud-cli`](https://github.com/dhoeric/features/tree/main/src/google-cloud-cli). It ships two fixes that have been pending upstream for over half a year:
@@ -27,3 +47,8 @@ Shells: `bash`, `zsh`, `fish`
 
 - Upstream: [dhoeric/features/src/google-cloud-cli](https://github.com/dhoeric/features/tree/main/src/google-cloud-cli)
 - Pending upstream fix: [dhoeric/features#36](https://github.com/dhoeric/features/pull/36)
+
+
+---
+
+_Note: This file was auto-generated from the [devcontainer-feature.json](https://github.com/joshuanianji/devcontainer-features/blob/main/src/google-cloud-cli/devcontainer-feature.json).  Add additional notes to a `NOTES.md`._

--- a/src/google-cloud-cli/devcontainer-feature.json
+++ b/src/google-cloud-cli/devcontainer-feature.json
@@ -1,0 +1,22 @@
+{
+    "name": "Google Cloud CLI",
+    "id": "google-cloud-cli",
+    "version": "1.0.0",
+    "documentationURL": "https://github.com/joshuanianji/devcontainer-features/tree/main/src/google-cloud-cli",
+    "description": "Installs the Google Cloud CLI (gcloud) via Google's apt repository. Forked from ghcr.io/dhoeric/features/google-cloud-cli with a trixie-compatible key import (`gpg --dearmor` instead of the removed `apt-key`).",
+    "options": {
+        "version": {
+            "type": "string",
+            "default": "latest",
+            "description": "Select or enter a gcloud CLI version"
+        },
+        "installGkeGcloudAuthPlugin": {
+            "type": "boolean",
+            "default": false,
+            "description": "Install 'gke-gcloud-auth-plugin' plugin?"
+        }
+    },
+    "installsAfter": [
+        "ghcr.io/devcontainers/features/common-utils"
+    ]
+}

--- a/src/google-cloud-cli/install.sh
+++ b/src/google-cloud-cli/install.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+
+set -e
+
+# Clean up
+rm -rf /var/lib/apt/lists/*
+
+GCLOUD_VERSION=${VERSION:-"latest"}
+
+# NOTE: devcontainer feature option resolution uppercases the option name
+# (`installGkeGcloudAuthPlugin` -> `INSTALLGKEGCLOUDAUTHPLUGIN`). The upstream
+# dhoeric feature reads `INSTALL_GKEGCLOUDAUTH_PLUGIN` (with an underscore),
+# which is never set, so the option silently does nothing there. We read the
+# correctly-named variable; fall back to the underscore form for safety.
+INSTALL_GKE_GCLOUD_AUTH_PLUGIN="${INSTALLGKEGCLOUDAUTHPLUGIN:-${INSTALL_GKE_GCLOUD_AUTH_PLUGIN:-"false"}}"
+
+if [ "$(id -u)" -ne 0 ]; then
+    echo -e 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
+    exit 1
+fi
+
+apt_get_update()
+{
+    echo "Running apt-get update..."
+    apt-get update -y
+}
+
+# Checks if packages are installed and installs them if not
+check_packages() {
+    if ! dpkg -s "$@" > /dev/null 2>&1; then
+        if [ "$(find /var/lib/apt/lists/* | wc -l)" = "0" ]; then
+            apt_get_update
+        fi
+        apt-get -y install --no-install-recommends "$@"
+    fi
+}
+
+export DEBIAN_FRONTEND=noninteractive
+
+# Soft version matching that resolves a version for a given package in the *current apt-cache*
+# Return value is stored in first argument (the unprocessed version)
+apt_cache_version_soft_match() {
+
+    # Version
+    local variable_name="$1"
+    local requested_version=${!variable_name}
+    # Package Name
+    local package_name="$2"
+
+    # Ensure we've exported useful variables
+    . /etc/os-release
+    local architecture="$(dpkg --print-architecture)"
+
+    dot_escaped="${requested_version//./\\.}"
+    dot_plus_escaped="${dot_escaped//+/\\+}"
+    # Regex needs to handle debian package version number format: https://www.systutorials.com/docs/linux/man/5-deb-version/
+    version_regex="^(.+:)?${dot_plus_escaped}([\\.\\+ ~:-]|$)"
+    set +e # Don't exit if finding version fails - handle gracefully
+        fuzzy_version="$(apt-cache madison ${package_name} | awk -F"|" '{print $2}' | sed -e 's/^[ \t]*//' | grep -E -m 1 "${version_regex}")"
+    set -e
+    if [ -z "${fuzzy_version}" ]; then
+        echo "(!) No full or partial for package \"${package_name}\" match found in apt-cache for \"${requested_version}\" on OS ${ID} ${VERSION_CODENAME} (${architecture})."
+        echo "Available versions:"
+        apt-cache madison ${package_name} | awk -F"|" '{print $2}' | grep -oP '^(.+:)?\K.+'
+        exit 1 # Fail entire script
+    fi
+
+    # Globally assign fuzzy_version to this value
+    # Use this value as the return value of this function
+    declare -g ${variable_name}="=${fuzzy_version}"
+    echo "${variable_name} ${!variable_name}"
+}
+
+install_using_apt() {
+    # Install dependencies
+    check_packages apt-transport-https curl ca-certificates gnupg python3
+    # Import key.
+    # NOTE: the upstream `ghcr.io/dhoeric/features/google-cloud-cli` feature uses
+    # `apt-key` here, which was removed in Debian 13 (trixie) / Ubuntu 24.04.
+    # `gpg --dearmor` is the modern replacement (see dhoeric/features#36).
+    curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg
+    echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
+    apt_get_update
+
+    if [ "${GCLOUD_VERSION}" = "latest" ]; then
+        # Empty, meaning grab the "latest" in the apt repo
+        GCLOUD_VERSION=""
+    else
+        # Sets GCLOUD_VERSION to our desired version, if match found.
+        apt_cache_version_soft_match GCLOUD_VERSION "google-cloud-cli"
+        if [ "$?" != 0 ]; then
+            return 1
+        fi
+    fi
+
+    if ! (apt-get install -yq google-cloud-cli${GCLOUD_VERSION}); then
+        rm -f /etc/apt/sources.list.d/google-cloud-sdk.list
+        return 1
+    fi
+
+    # Install gke-gcloud-auth-plugin if needed
+    if [ "${INSTALL_GKE_GCLOUD_AUTH_PLUGIN}" = "true" ]; then
+        echo "(*) Installing 'gke-gcloud-auth-plugin' plugin..."
+        check_packages google-cloud-sdk-gke-gcloud-auth-plugin
+    fi
+}
+
+echo "(*) Installing google-cloud CLI..."
+. /etc/os-release
+
+# Install
+install_using_apt
+
+# Clean up
+rm -rf /var/lib/apt/lists/*
+
+echo "Done!"

--- a/test/google-cloud-cli/_default.sh
+++ b/test/google-cloud-cli/_default.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+set -e
+
+# Default test script that tests everything.
+# It is not run as a scenario on its own, but is invoked by the per-scenario
+# scripts.
+
+# Optional: Import test library
+source dev-container-features-test-lib
+
+# check that `gcloud --version` works and reports the SDK name
+check "gcloud --version" bash -c "gcloud --version | grep 'Google Cloud SDK'"
+
+# check the binary is on PATH for the remote user
+check "gcloud on PATH" bash -c "command -v gcloud"
+
+# Report result
+reportResults

--- a/test/google-cloud-cli/bookworm.sh
+++ b/test/google-cloud-cli/bookworm.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+set -e
+
+./_default.sh

--- a/test/google-cloud-cli/latest.sh
+++ b/test/google-cloud-cli/latest.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+set -e
+
+# Run default test script
+./_default.sh

--- a/test/google-cloud-cli/root_user.sh
+++ b/test/google-cloud-cli/root_user.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+set -e
+
+./_default.sh

--- a/test/google-cloud-cli/scenarios.json
+++ b/test/google-cloud-cli/scenarios.json
@@ -1,0 +1,58 @@
+{
+    "latest": {
+        "image": "mcr.microsoft.com/devcontainers/base:debian",
+        "features": {
+            "google-cloud-cli": {}
+        }
+    },
+    "trixie": {
+        "image": "mcr.microsoft.com/devcontainers/base:debian-13",
+        "features": {
+            "google-cloud-cli": {}
+        }
+    },
+    "bookworm": {
+        "image": "mcr.microsoft.com/devcontainers/base:debian-12",
+        "features": {
+            "google-cloud-cli": {}
+        }
+    },
+    "ubuntu": {
+        "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+        "features": {
+            "google-cloud-cli": {}
+        }
+    },
+    "with_version": {
+        "image": "mcr.microsoft.com/devcontainers/base:debian",
+        "features": {
+            "google-cloud-cli": {
+                "version": "latest"
+            }
+        }
+    },
+    "with_gke_plugin": {
+        "image": "mcr.microsoft.com/devcontainers/base:debian",
+        "features": {
+            "google-cloud-cli": {
+                "installGkeGcloudAuthPlugin": true
+            }
+        }
+    },
+    "root_user": {
+        "image": "mcr.microsoft.com/devcontainers/base:debian",
+        "features": {
+            "google-cloud-cli": {}
+        },
+        "remoteUser": "root"
+    },
+    "zsh_shell": {
+        "image": "mcr.microsoft.com/devcontainers/base:debian",
+        "features": {
+            "ghcr.io/devcontainers/features/common-utils:2": {
+                "configureZshAsDefaultShell": true
+            },
+            "google-cloud-cli": {}
+        }
+    }
+}

--- a/test/google-cloud-cli/test.sh
+++ b/test/google-cloud-cli/test.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -e
+
+# Optional: Import test library
+source dev-container-features-test-lib
+
+# Auto-generated test: runs against the bare feature with no other features
+# installed, so we just check that gcloud is on PATH and reports its version.
+
+check "gcloud on PATH" bash -c "command -v gcloud"
+check "gcloud --version" bash -c "gcloud --version | grep 'Google Cloud SDK'"
+
+# Report result
+reportResults

--- a/test/google-cloud-cli/trixie.sh
+++ b/test/google-cloud-cli/trixie.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -e
+
+# Regression test for trixie-compatible key handling (issue #90):
+# the upstream `ghcr.io/dhoeric/features/google-cloud-cli` feature uses
+# `apt-key`, which was removed in Debian 13 (trixie), so the build fails
+# with `apt-key: command not found`. This scenario proves our fork installs
+# cleanly on trixie by reaching this script at all.
+
+./_default.sh

--- a/test/google-cloud-cli/ubuntu.sh
+++ b/test/google-cloud-cli/ubuntu.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+set -e
+
+./_default.sh

--- a/test/google-cloud-cli/with_gke_plugin.sh
+++ b/test/google-cloud-cli/with_gke_plugin.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -e
+
+# Optional: Import test library
+source dev-container-features-test-lib
+
+# check that `gcloud --version` works
+check "gcloud --version" bash -c "gcloud --version | grep 'Google Cloud SDK'"
+
+# check the gke-gcloud-auth-plugin package is installed via apt
+check "gke-gcloud-auth-plugin installed" bash -c "dpkg -s google-cloud-sdk-gke-gcloud-auth-plugin"
+
+# Report result
+reportResults

--- a/test/google-cloud-cli/with_version.sh
+++ b/test/google-cloud-cli/with_version.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+set -e
+
+./_default.sh

--- a/test/google-cloud-cli/zsh_shell.sh
+++ b/test/google-cloud-cli/zsh_shell.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+set -e
+
+./_default.sh


### PR DESCRIPTION
Fixes #90.

```
$ devcontainer features test -f google-cloud-cli --skip-autogenerated
✅ Passed:      'latest'
✅ Passed:      'trixie'
✅ Passed:      'bookworm'
✅ Passed:      'ubuntu'
✅ Passed:      'with_version'
✅ Passed:      'with_gke_plugin'
✅ Passed:      'root_user'
✅ Passed:      'zsh_shell'
```

Also verified the autogenerated test passes against the CI matrix images (`debian:latest`, `ubuntu:latest`, `mcr.microsoft.com/devcontainers/base:ubuntu`).

## What

Fork of [`ghcr.io/dhoeric/features/google-cloud-cli`](https://github.com/dhoeric/features/tree/main/src/google-cloud-cli) with two fixes that have been pending upstream for over half a year:

1. **Trixie-compatible apt key import.** Replaces `apt-key` (removed in Debian 13 trixie / Ubuntu 24.04, so it fails with `apt-key: command not found`) with `gpg --dearmor` — the fix from [dhoeric/features#36](https://github.com/dhoeric/features/pull/36).
2. **Working `installGkeGcloudAuthPlugin` option.** The devcontainer runtime exposes options uppercased *without* underscores (`installGkeGcloudAuthPlugin` -> `INSTALLGKEGCLOUDAUTHPLUGIN`). The upstream feature reads `INSTALL_GKEGCLOUDAUTH_PLUGIN` (with an underscore), which is never set, so the option silently does nothing there. We read the correctly-named variable.

## Why

[dhoeric/features#36](https://github.com/dhoeric/features/pull/36) has been open for half a year and is blocking Debian 13 / Ubuntu 24.04 updates. We needed a fix in the meantime (#90).

## Follow-up (separate PR)

Once this feature is published to `ghcr.io/joshuanianji/devcontainer-features/google-cloud-cli`, a follow-up PR will:

- Switch `gcloud-cli-persistence`'s `installsAfter` from `ghcr.io/dhoeric/features/google-cloud-cli` to `ghcr.io/joshuanianji/devcontainer-features/google-cloud-cli`.
- Update `gcloud-cli-persistence` test scenarios to use the new feature.
- Un-pin the `zsh_shell` and `root_user` scenarios from `debian-12` (the workaround put in place by #89, no longer needed once we no longer depend on dhoeric).

`installsAfter` can't reference this feature in *this* PR because the devcontainer CLI resolves `installsAfter` from the registry at test time and the feature isn't published yet.