### PR TITLE
refactor(mount-pnpm-store): point pnpm at the volume via containerEnv

### DIFF
--- a/src/mount-pnpm-store/NOTES.md
+++ b/src/mount-pnpm-store/NOTES.md
@@ -1,54 +1,59 @@
+## How it works
+
+This feature shares one pnpm content-addressable store across every devcontainer on the host, so each package is downloaded and unpacked only once.
+
+It does this with four declarative pieces and **no pnpm invocation**:
+
+- **Named volume** `global-devcontainer-pnpm-store` mounted at `/dc/mounted-pnpm-store`. A named volume (not a workspace bind mount) is shared by all containers on the host — that is the entire sharing mechanism.
+- **`containerEnv`** relocates the store with `NPM_CONFIG_STORE_DIR=/dc/mounted-pnpm-store`. pnpm honors `npm_config_*`-style settings, so this is the variable that actually moves the store across pnpm versions. `PNPM_CONFIG_STORE_DIR` is set to the same value as forward-looking coverage for pnpm's native `PNPM_CONFIG_*` variables (not honored for `store-dir` on pnpm 10.x, but harmless).
+- **`install.sh`** creates the mount point and gives it to the remote user.
+- **`oncreate.sh`** (`onCreateCommand`) re-asserts ownership for the current non-root user on every container create.
+
+Because pnpm is never invoked, this feature avoids the `pnpm config set --global` / `PNPM_HOME` / PATH / non-interactive-shell problems that earlier versions (and the `~/.pnpm-store` symlink approach) had to patch. See issue [#80](https://github.com/joshuanianji/devcontainer-features/issues/80).
+
+### Migrating from `1.0.x`
+
+Version `1.1.0` is a behavior change: the `~/.pnpm-store` symlink is no longer created and pnpm is no longer invoked at onCreate. Instead, pnpm is pointed at the volume via `NPM_CONFIG_STORE_DIR`. The Docker volume name (`global-devcontainer-pnpm-store`) and mount target (`/dc/mounted-pnpm-store`) are unchanged, so existing volumes keep working — pnpm will simply read/write the same store at the same path.
+
+A stale `~/.pnpm-store` symlink from a previous version is harmless (it still resolves to the mounted volume) and can be ignored; `NPM_CONFIG_STORE_DIR` takes precedence over any `store-dir` written to `~/.npmrc` by earlier versions.
+
+## Ownership of the shared store
+
+The named volume is mounted over `/dc/mounted-pnpm-store` at runtime, so the build-time `chown` in `install.sh` only sticks the first time the volume is created. `oncreate.sh` therefore `sudo chown`s the store to the current user on every create (skipped when running as `root`).
+
+Note: if you use the same volume from devcontainers running as **different** users at the same time, each container's `onCreateCommand` will chown the store to its own user. This is inherent to sharing one store across users. The intended use is a single developer with a consistent remote user.
+
+## Ensuring pnpm is installed
+
+This feature does not install pnpm. It only configures where pnpm puts its store, so it works whether pnpm comes from the base image or another feature. There is a soft dependency (`installsAfter`) on `ghcr.io/devcontainers/features/node`, `common-utils`, and `fish`. If pnpm is installed by some other feature, you may need [`overrideFeatureInstallOrder`](https://containers.dev/implementors/features/#overrideFeatureInstallOrder) to make sure it runs before this one.
+
 ## OS and Architecture Support
 
 Architectures: `amd` and `arm`
 
 OS: `ubuntu`, `debian`
 
-Shells: `bash`, `zsh`, `fish`
+Shells: `bash`, `zsh`, `fish` (the feature sets environment only; it does not depend on the interactive shell)
 
-## Important Implementation Details
+## Volume Mount Naming
 
-### pnpm `store-dir`
-
-This is opinionated, but I dislike the pnpm store being in the workspace along with your code as it adds clutter. This feature sets the pnpm `store-dir` config to `~/.pnpm-store`, so it's out of sight. The home directory will be based on the `remoteUser` of the base image you have.
-
-### Ensuring pnpm is installed
-
-This feature does not install pnpm by itself and expects `pnpm` to be installed already, either by a base image or by a feature. If pnpm is not installed, it just gives a warning (you'll have a random ~/.pnpm-store folder in your home directory and the pnpm `store-dir` config will not be set) but does not fail.
-
-If you are installing pnpm with a feature, you may need to ensure it is run **before** `mount-pnpm-store`. I have set a soft dependency on `ghcr.io/devcontainers/features/node` already, but if it is any other feature that installs pnpm you might need to put some extra work.
-
-To make this work, use the [`overrideFeatureInstallOrder` property](https://containers.dev/implementors/features/#overrideFeatureInstallOrder), since the default feature installation order is based on ID (alphanumerically i think). Here is an example using a fake `unknown-install-pnpm`:
-
-```json
-    "image": "mcr.microsoft.com/devcontainers/base:bullseye",
-    "features": {
-        "ghcr.io/random-user/devcontainer-features/unknown-install-pnpm:1": {},
-        "ghcr.io/joshuanianji/devcontainer-features/mount-pnpm-store:1": {}
-    },
-    "overrideFeatureInstallOrder": [
-        "ghcr.io/random-user/devcontainer-features/unknown-install-pnpm", 
-        "ghcr.io/joshuanianji/devcontainer-features/mount-pnpm-store"
-    ]
-```
-
-### Volume Mount Naming
-
-The volume mount is called `global-devcontainer-pnpm-store`, so ensure that no other docker volumes match this name.
+The volume is named `global-devcontainer-pnpm-store`. Ensure no other Docker volume collides with this name.
 
 ## Changelog
 
-| Version | Notes                                                      |
-| ------- | ---------------------------------------------------------- |
-| 1.0.4   | Fix script name in output                                  |
-| 1.0.3   | Fix pnpm global bin dir check in `oncreate.sh` (issue #80) |
-| 1.0.2   | Move onCreate lifecycle script to `oncreate.sh`            |
-| 1.0.1   | Fix Docs                                                   |
-| 1.0.0   | Support zsh + refactor                                     |
-| 0.1.1   | Fix mount name                                             |
-| 0.1.0   | Documentation                                              |
-| 0.0.0   | Initial Version                                            |
+| Version | Notes                                                                                                                                   |
+| ------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| 1.1.0   | Switch to declarative `containerEnv` strategy: point pnpm at the volume via `NPM_CONFIG_STORE_DIR`, drop the symlink and pnpm invocation (resolves [#80](https://github.com/joshuanianji/devcontainer-features/issues/80) at the root). Pattern adapted from [itplusx/devcontainer-features/shared-pnpm-store](https://github.com/itplusx/devcontainer-features/tree/main/src/shared-pnpm-store). |
+| 1.0.4   | Fix script name in output                                                                                                               |
+| 1.0.3   | Fix pnpm global bin dir check in `oncreate.sh` (issue #80)                                                                              |
+| 1.0.2   | Move onCreate lifecycle script to `oncreate.sh`                                                                                         |
+| 1.0.1   | Fix Docs                                                                                                                                |
+| 1.0.0   | Support zsh + refactor                                                                                                                  |
+| 0.1.1   | Fix mount name                                                                                                                          |
+| 0.1.0   | Documentation                                                                                                                           |
+| 0.0.0   | Initial Version                                                                                                                         |
 
 ## References
 
 - [Pnpm Devcontainer Setup by PatrickChoDev](https://gist.github.com/PatrickChoDev/81d36159aca4dc687b8c89983e64da2e)
+- [itplusx/devcontainer-features/shared-pnpm-store](https://github.com/itplusx/devcontainer-features/tree/main/src/shared-pnpm-store) — origin of the `containerEnv` pattern.

--- a/src/mount-pnpm-store/devcontainer-feature.json
+++ b/src/mount-pnpm-store/devcontainer-feature.json
@@ -1,10 +1,14 @@
 {
     "name": "Mount pnpm Store",
     "id": "mount-pnpm-store",
-    "version": "1.0.4",
+    "version": "1.1.0",
     "documentationURL": "https://github.com/joshuanianji/devcontainer-features/tree/main/src/mount-pnpm-store",
-    "description": "Sets pnpm store to ~/.pnpm-store and mounts it to a volume to share between multiple devcontainers",
+    "description": "Mounts a shared Docker volume as the pnpm store directory so packages are downloaded once and reused across multiple devcontainers. Points pnpm at the volume via containerEnv — no pnpm invocation, no symlink.",
     "options": {},
+    "containerEnv": {
+        "PNPM_CONFIG_STORE_DIR": "/dc/mounted-pnpm-store",
+        "NPM_CONFIG_STORE_DIR": "/dc/mounted-pnpm-store"
+    },
     "mounts": [
         {
             "source": "global-devcontainer-pnpm-store",

--- a/src/mount-pnpm-store/install.sh
+++ b/src/mount-pnpm-store/install.sh
@@ -1,52 +1,28 @@
 #!/bin/sh
 
-USERNAME=${USERNAME:-${_REMOTE_USER}}
-FEATURE_ID="mount-pnpm-store"
-LIFECYCLE_SCRIPTS_DIR="/usr/local/share/${FEATURE_ID}/scripts"
-
 set -e
 
-create_cache_dir() {
-    if [ -d "$1" ]; then
-        echo "Cache directory $1 already exists. Skip creation..."
-    else
-        echo "Create cache directory $1..."
-        mkdir -p "$1"
-    fi
+USERNAME=${USERNAME:-${_REMOTE_USER}}
+FEATURE_ID="mount-pnpm-store"
+STORE_DIR="/dc/mounted-pnpm-store"
+LIFECYCLE_SCRIPTS_DIR="/usr/local/share/${FEATURE_ID}/scripts"
 
-    if [ -z "$2" ]; then
-        echo "No username provided. Skip chown..."
-    else
-        echo "Change owner of $1 to $2..."
-        chown -R "$2:$2" "$1"
-    fi
-}
+echo "Ensuring pnpm store directory ${STORE_DIR} exists..."
+mkdir -p "${STORE_DIR}"
 
-create_symlink_dir() {
-    local local_dir=$1
-    local cache_dir=$2
-    local username=$3
-
-    runuser -u "$username" -- mkdir -p "$(dirname "$local_dir")"
-    runuser -u "$username" -- mkdir -p "$cache_dir"
-
-    # if the folder we want to symlink already exists, the ln -s command will create a folder inside the existing folder
-    if [ -e "$local_dir" ]; then
-        echo "Moving existing $local_dir folder to $local_dir-old"
-        mv "$local_dir" "$local_dir-old"
-    fi
-
-    echo "Symlink $local_dir to $cache_dir for $username..."
-    runuser -u "$username" -- ln -s "$cache_dir" "$local_dir"
-}
-
-create_cache_dir "/dc/mounted-pnpm-store" "${USERNAME}"
-create_symlink_dir "$_REMOTE_USER_HOME/.pnpm-store" "/dc/mounted-pnpm-store" "${USERNAME}"
-
-# Set Lifecycle scripts
-if [ -f oncreate.sh ]; then
-    mkdir -p "${LIFECYCLE_SCRIPTS_DIR}"
-    cp oncreate.sh "${LIFECYCLE_SCRIPTS_DIR}/oncreate.sh"
+if [ -n "${USERNAME}" ] && [ "${USERNAME}" != "root" ]; then
+    echo "Setting owner of ${STORE_DIR} to ${USERNAME}..."
+    chown -R "${USERNAME}:${USERNAME}" "${STORE_DIR}"
+else
+    echo "No non-root user; leaving ${STORE_DIR} owned by root."
 fi
 
-echo "Finished installing $FEATURE_ID"
+# Install lifecycle script (re-asserts ownership at container create time)
+if [ -f oncreate.sh ]; then
+    echo "Installing oncreate.sh to ${LIFECYCLE_SCRIPTS_DIR}..."
+    mkdir -p "${LIFECYCLE_SCRIPTS_DIR}"
+    cp oncreate.sh "${LIFECYCLE_SCRIPTS_DIR}/oncreate.sh"
+    chmod +x "${LIFECYCLE_SCRIPTS_DIR}/oncreate.sh"
+fi
+
+echo "Finished installing ${FEATURE_ID}"

--- a/src/mount-pnpm-store/oncreate.sh
+++ b/src/mount-pnpm-store/oncreate.sh
@@ -2,26 +2,17 @@
 
 set -e
 
-# pnpm refuses --global commands (exit 1) when its global bin directory is
-# not in PATH. This script runs as onCreateCommand in a non-interactive shell
-# where rc-file exports are never loaded, so provide the environment here.
-# The expected directory differs by pnpm version ($PNPM_HOME for pnpm <= 8,
-# $PNPM_HOME/bin for pnpm >= 9), so put both on PATH; neither needs to exist
-# for the check to pass.
-export PNPM_HOME="${PNPM_HOME:-$HOME/.local/share/pnpm}"
-export PATH="$PNPM_HOME/bin:$PNPM_HOME:$PATH"
+STORE_DIR="/dc/mounted-pnpm-store"
 
-# set pnpm config (if it's installed)
-if type pnpm >/dev/null 2>&1; then
-    echo "Setting pnpm store location to $HOME/.pnpm-store"
-    pnpm config set store-dir ~/.pnpm-store --global
-else
-    echo "WARN: pnpm is not installed! Please ensure pnpm is installed and in your PATH."
-    echo "WARN: pnpm store location will not be set."
-fi
-
-# if the user is not root, chown /dc/mounted-pnpm-store to the user
+# The shared named volume is mounted over STORE_DIR at runtime, so build-time
+# ownership only sticks the first time the volume is created. Re-assert
+# ownership for the current non-root user on every container create so pnpm can
+# always write to the store, even if the volume was first created by root or a
+# different user.
 if [ "$(id -u)" != "0" ]; then
-    echo "Running oncreate.sh for user $USER"
-    sudo chown -R "$USER:$USER" /dc/mounted-pnpm-store
+    USERNAME="$(id -un)"
+    echo "Setting owner of ${STORE_DIR} to ${USERNAME}..."
+    sudo chown -R "${USERNAME}:${USERNAME}" "${STORE_DIR}"
+else
+    echo "Running as root; leaving ${STORE_DIR} ownership unchanged."
 fi

--- a/test/mount-pnpm-store/_default.sh
+++ b/test/mount-pnpm-store/_default.sh
@@ -2,26 +2,25 @@
 
 set -e
 
-# Default test script that tests everything
-# It is not run as a scenario, but is run by other test scripts.
+# Default test script that tests everything.
+# It is not run as a scenario on its own, but is invoked by the per-scenario
+# scripts.
 
 # Optional: Import test library
 source dev-container-features-test-lib
 
-# user is `node` in dev container
-
 echo "User: $(whoami)"
 pnpm config list
 
-# check that `pnpm config get store-dir` equals ~/.pnpm-store
+# check that `pnpm config get store-dir` equals the mounted volume path.
+# `NPM_CONFIG_STORE_DIR` from containerEnv is what populates this; the
+# feature itself never invokes pnpm.
 pnpmConfig=$(pnpm config get store-dir)
 echo "pnpm config get store-dir: '$pnpmConfig'"
-check "config" test $pnpmConfig = "$(echo ~)/.pnpm-store"
+check "store-dir points at mounted volume" bash -c "test \"$pnpmConfig\" = '/dc/mounted-pnpm-store'"
 
-# check that the folders are owned by the user
-# https://askubuntu.com/a/175060
+# check that `/dc/mounted-pnpm-store` exists and is owned by the user
 echo "Checking ownership of /dc/mounted-pnpm-store (ensure it is owned by $USER)"
-
 check "/dc/mounted-pnpm-store owned by user" bash -c "test \"$(stat -c "%U" /dc/mounted-pnpm-store)\" = $USER"
 
 # Report result

--- a/test/mount-pnpm-store/node_v2.sh
+++ b/test/mount-pnpm-store/node_v2.sh
@@ -3,13 +3,14 @@
 set -e
 
 # Regression test for the pnpm >= 9 global bin dir check (issue #80):
-# node feature v2 installs latest pnpm by default, which made the
-# unpatched oncreate.sh fail the container build with
-# "The configured global bin directory ... is not in PATH".
-# Reaching this script at all proves onCreateCommand survived.
-
-# The test shell is non-interactive too, so it needs the same env
-# the patched oncreate.sh provides for itself.
+# in v1.0.x, `oncreate.sh` ran `pnpm config set --global` in a non-interactive
+# shell where pnpm's global bin dir wasn't on PATH, so it failed the container
+# build. v1.1.0 removed the pnpm invocation entirely; reaching this script at
+# all proves onCreateCommand survived.
+#
+# The test shell is non-interactive too, so it still needs PNPM_HOME in PATH
+# for `pnpm config get store-dir` (in _default.sh) to find the pnpm binary —
+# independent of the feature itself.
 export PNPM_HOME="${PNPM_HOME:-$HOME/.local/share/pnpm}"
 export PATH="$PNPM_HOME/bin:$PATH"
 

--- a/test/mount-pnpm-store/test.sh
+++ b/test/mount-pnpm-store/test.sh
@@ -5,21 +5,20 @@ set -e
 # Optional: Import test library
 source dev-container-features-test-lib
 
-# NOTE: this is an "auto-generated" test, which means it will be 
+# NOTE: this is an "auto-generated" test, which means it will be
 # executed against an auto-generated devcontainer.json that
 # includes the 'mount-pnpm-store' feature with no options.
 #
 # https://github.com/devcontainers/cli/blob/main/docs/features/test.md
 #
-# From my tests, this means the `pnpm` CLI will not be installed
+# From our tests, this means the `pnpm` CLI will not be installed,
+# so we only verify the mount point and the env var (no pnpm call).
 
-# check that `~/.pnpm-store` and `/dc/mounted-pnpm-store` exist`
-check "config" bash -c "ls -la ~ | grep '.pnpm-store'"
+# check that `/dc/mounted-pnpm-store` exists
 check "dc" bash -c "ls -la /dc | grep 'mounted-pnpm-store'"
 
-# check that `~/.pnpm-store` is a symlink
-# https://unix.stackexchange.com/a/96910
-check "~/.pnpm-store is a symlink" bash -c "test -L ~/.pnpm-store && test -d ~/.pnpm-store"
+# check the containerEnv var is set (this is what actually relocates the store)
+check "NPM_CONFIG_STORE_DIR" bash -c "test \"$NPM_CONFIG_STORE_DIR\" = '/dc/mounted-pnpm-store'"
 
 # Report result
 reportResults


### PR DESCRIPTION
Adopts the declarative pattern from [itplusx/devcontainer-features/shared-pnpm-store](https://github.com/itplusx/devcontainer-features/tree/main/src/shared-pnpm-store) — a strictly better strategy than the current symlink + `pnpm config set --global` one. Mentioned in #80.

```
$ devcontainer features test -f mount-pnpm-store --skip-autogenerated
✅ Passed:      'with_node'
✅ Passed:      'pnpm_from_feature'
✅ Passed:      'node_v2'
✅ Passed:      'zsh_shell'
✅ Passed:      'root_user'
```

Also verified the autogenerated test passes against the CI matrix images (`debian:latest`, `ubuntu:latest`, `mcr.microsoft.com/devcontainers/base:ubuntu`).

## What

Set `NPM_CONFIG_STORE_DIR=/dc/mounted-pnpm-store` (and the forward-looking `PNPM_CONFIG_STORE_DIR`) via `containerEnv`, so pnpm reads/writes the mounted volume directly.

| | v1.0.x | v1.1.0 |
| --- | --- | --- |
| Strategy | symlink `~/.pnpm-store` -> `/dc/mounted-pnpm-store` + `pnpm config set --global` | `containerEnv` `NPM_CONFIG_STORE_DIR` -> `/dc/mounted-pnpm-store` |
| pnpm invoked at onCreate? | yes (and fragile) | no |
| `PNPM_HOME`/PATH workaround needed? | yes (#80, fixed in v1.0.3) | no |
| Volume name / target | `global-devcontainer-pnpm-store` @ `/dc/mounted-pnpm-store` | unchanged |

## Why

The v1.0.x `oncreate.sh` ran `pnpm config set --global` inside a non-interactive shell where pnpm's global bin dir wasn't on PATH, which is what made `onCreateCommand` blow up in [#80](https://github.com/joshuanianji/devcontainer-features/issues/80). v1.0.3 only papered over the symptom by exporting `PNPM_HOME`/`PATH` inside `oncreate.sh`. This version doesn't invoke pnpm at all during the lifecycle, so the class of problem goes away entirely.

## Compatibility

- **Volume name + mount target are unchanged.** Existing volumes keep working; pnpm just reads/writes the same store at the same path.
- **A stale `~/.pnpm-store` symlink from v1.0.x is harmless** (it still resolves to the mounted volume) — `NPM_CONFIG_STORE_DIR` takes precedence over any `store-dir` written to `~/.npmrc` by earlier versions.
- pnpm still resolves the store via `npm_config_*` precedence across pnpm 8/9/10.

## Credits

Pattern adapted from [itplusx/devcontainer-features/shared-pnpm-store](https://github.com/itplusx/devcontainer-features/tree/main/src/shared-pnpm-store).